### PR TITLE
fix(formatting): make formatted examples more readable

### DIFF
--- a/files/en-us/web/html/element/dfn/index.md
+++ b/files/en-us/web/html/element/dfn/index.md
@@ -49,10 +49,9 @@ This example uses a plain `<dfn>` element to identify the location of a term wit
 
 ```html
 <p>
-  The <strong>HTML Definition element</strong> (<strong
-    ><dfn>&lt;dfn&gt;</dfn></strong
-  >) is used to indicate the term being defined within the context of a
-  definition phrase or sentence.
+  The <strong>HTML Definition element (<dfn>&lt;dfn&gt;</dfn>)</strong> is used
+  to indicate the term being defined within the context of a definition phrase
+  or sentence.
 </p>
 ```
 
@@ -68,29 +67,18 @@ To add links to the definitions, you create the link the same way you always do,
 
 #### HTML
 
-```html
+```html-nolint
 <p>
-  The <strong>HTML Definition element</strong> (<strong
-    ><dfn id="definition-dfn">&lt;dfn&gt;</dfn></strong
-  >) is used to indicate the term being defined within the context of a
-  definition phrase or sentence.
+  The
+  <strong>HTML Definition element (<dfn id="definition-dfn">&lt;dfn&gt;</dfn>)</strong>
+  is used to indicate the term being defined within the context of a definition
+  phrase or sentence.
 </p>
 
 <p>
   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Graece donan, Latine
   voluptatem vocant. Confecta res esset. Duo Reges: constructio interrete.
   Scrupulum, inquam, abeunti;
-</p>
-
-<p>
-  Negare non possum. Dat enim intervalla et relaxat. Quonam modo? Equidem e Cn.
-  Quid de Pythagora? In schola desinis.
-</p>
-
-<p>
-  Ubi ut eam caperet aut quando? Cur iustitia laudatur? Aperiendum est igitur,
-  quid sit voluptas; Quid enim? Non est igitur voluptas bonum. Urgent tamen et
-  nihil remittunt. Quid enim possumus hoc agere divinius?
 </p>
 
 <p>
@@ -138,25 +126,18 @@ Note the `<abbr>` element nested inside the `<dfn>`. The former establishes that
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
-          >Content categories</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >Flow content</a
-        >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content"
-          >phrasing content</a
-        >, palpable content.
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">Flow content</a>,
+        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">phrasing content</a>, palpable content.
       </td>
     </tr>
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content"
-          >Phrasing content</a
-        >, but no {{HTMLElement("dfn")}} element must be a descendant.
+        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">Phrasing content</a>,
+        but no {{HTMLElement("dfn")}} element must be a descendant.
       </td>
     </tr>
     <tr>
@@ -167,9 +148,7 @@ Note the `<abbr>` element nested inside the `<dfn>`. The former establishes that
       <th scope="row">Permitted parents</th>
       <td>
         Any element that accepts
-        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content"
-          >phrasing content</a
-        >.
+        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">phrasing content</a>.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -66,8 +66,8 @@ This example opens a modal dialog when the "Show the dialog" button is activated
 <dialog id="favDialog">
   <form>
     <p>
-      <label
-        >Favorite animal:
+      <label>
+        Favorite animal:
         <select>
           <option value="default">Choose…</option>
           <option>Brine shrimp</option>
@@ -136,25 +136,17 @@ It is important to provide a closing mechanism within every `dialog` element. Th
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
-          >Content categories</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >Flow content</a
-        >,
-        <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots"
-          >sectioning root</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">Flow content</a>,
+        <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots">sectioning root</a>
       </td>
     </tr>
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >Flow content</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">Flow content</a>
       </td>
     </tr>
     <tr>
@@ -165,17 +157,13 @@ It is important to provide a closing mechanism within every `dialog` element. Th
       <th scope="row">Permitted parents</th>
       <td>
         Any element that accepts
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >flow content</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">flow content</a>
       </td>
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role"
-          >dialog</a
-        >
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role">dialog</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/footer/index.md
+++ b/files/en-us/web/html/element/footer/index.md
@@ -15,22 +15,16 @@ The **`<footer>`** [HTML](/en-US/docs/Web/HTML) element represents a footer for 
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
-          >Content categories</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >Flow content</a
-        >, palpable content.
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">Flow content</a>, palpable content.
       </td>
     </tr>
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >Flow content</a
-        >, but with no <code>&#x3C;footer></code> or
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">Flow content</a>, but with no <code>&#x3C;footer></code> or
         {{HTMLElement("header")}} descendants.
       </td>
     </tr>
@@ -42,9 +36,7 @@ The **`<footer>`** [HTML](/en-US/docs/Web/HTML) element represents a footer for 
       <th scope="row">Permitted parents</th>
       <td>
         Any element that accepts
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >flow content</a
-        >. Note that a <code>&#x3C;footer></code> element must not be a
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">flow content</a>. Note that a <code>&#x3C;footer></code> element must not be a
         descendant of an {{HTMLElement("address")}},
         {{HTMLElement("header")}} or another
         <code>&#x3C;footer></code> element.
@@ -53,12 +45,8 @@ The **`<footer>`** [HTML](/en-US/docs/Web/HTML) element represents a footer for 
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Contentinfo_role"
-          >contentinfo</a
-        >, or
-        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
-          >no corresponding role</a
-        >
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Contentinfo_role">contentinfo</a>, or
+        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role">no corresponding role</a>
         if a descendant of an
         <a href="/en-US/docs/Web/HTML/Element/article">article</a>,
         <a href="/en-US/docs/Web/HTML/Element/aside">aside</a>,
@@ -66,22 +54,12 @@ The **`<footer>`** [HTML](/en-US/docs/Web/HTML) element represents a footer for 
         <a href="/en-US/docs/Web/HTML/Element/nav">nav</a> or
         <a href="/en-US/docs/Web/HTML/Element/section">section</a> element, or
         an element with
-        <code
-          >role=<a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Article_Role"
-            >article</a
-          ></code
-        >,
-        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Complementary_role"
-          >complementary</a
-        >,
+        <code>role=<a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Article_Role">article</a></code>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Complementary_role">complementary</a>,
         <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Main_role">main</a>,
-        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Navigation_Role"
-          >navigation</a
-        >
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Navigation_Role">navigation</a>
         or
-        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Region_role"
-          >region</a
-        >
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Region_role">region</a>
       </td>
     </tr>
     <tr>
@@ -120,9 +98,9 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
   </ol>
 
   <footer>
-    <small
-      >Copyright © 2023 Football History Archives . All Rights Reserved.</small
-    >
+    <small>
+      Copyright © 2023 Football History Archives. All Rights Reserved.
+    </small>
   </footer>
 </body>
 ```

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -94,8 +94,8 @@ The following attributes control behavior during form submission.
 ```html
 <!-- Form which will send a GET request to the current URL -->
 <form method="get">
-  <label
-    >Name:
+  <label>
+    Name:
     <input name="submitted-name" autocomplete="name" />
   </label>
   <button>Save</button>
@@ -103,8 +103,8 @@ The following attributes control behavior during form submission.
 
 <!-- Form which will send a POST request to the current URL -->
 <form method="post">
-  <label
-    >Name:
+  <label>
+    Name:
     <input name="submitted-name" autocomplete="name" />
   </label>
   <button>Save</button>
@@ -130,25 +130,17 @@ The following attributes control behavior during form submission.
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
-          >Content categories</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >Flow content</a
-        >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#palpable_content"
-          >palpable content</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">Flow content</a>,
+        <a href="/en-US/docs/Web/HTML/Content_categories#palpable_content">palpable content</a>
       </td>
     </tr>
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >Flow content</a
-        >, but not containing <code>&#x3C;form></code> elements
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">Flow content</a>, but not containing <code>&#x3C;form></code> elements
       </td>
     </tr>
     <tr>
@@ -159,35 +151,23 @@ The following attributes control behavior during form submission.
       <th scope="row">Permitted parents</th>
       <td>
         Any element that accepts
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >flow content</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">flow content</a>
       </td>
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <code
-          ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/form_role"
-            >form</a
-          ></code
-        > if the form has an
-        <a href="https://www.w3.org/TR/accname-1.1/#dfn-accessible-name"
-          >accessible name</a
-        >, otherwise
-        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
-          >no corresponding role</a
-        >
+        <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/form_role">form</a></code> if the form has an
+        <a href="https://www.w3.org/TR/accname-1.1/#dfn-accessible-name">accessible name</a>, otherwise
+        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role">no corresponding role</a>
       </td>
     </tr>
     <tr>
       <th scope="row">Permitted ARIA roles</th>
       <td>
-        <code
-          ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/search_role"
-            >search</a
-          ></code
-        >, <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role"><code>none</code></a> or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role"><code>presentation</code></a>
+        <code><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/search_role">search</a></code>,
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/none_role"><code>none</code></a>
+         or <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role"><code>presentation</code></a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/kbd/index.md
+++ b/files/en-us/web/html/element/kbd/index.md
@@ -54,9 +54,8 @@ First, let's look at what this looks like as just plain HTML.
 
 ```html
 <p>
-  You can also create a new document using the keyboard shortcut
-  <kbd><kbd>Ctrl</kbd>+<kbd>N</kbd></kbd
-  >.
+  You can also create a new document using the
+  <kbd><kbd>Ctrl</kbd>+<kbd>N</kbd></kbd> keyboard shortcut.
 </p>
 ```
 
@@ -94,9 +93,8 @@ Then we update the HTML to use this class on the keys in the output to be presen
 
 ```html
 <p>
-  You can also create a new document by pressing
-  <kbd><kbd>Ctrl</kbd>+<kbd>N</kbd></kbd
-  >.
+  You can also create a new document by pressing the
+  <kbd><kbd>Ctrl</kbd>+<kbd>N</kbd></kbd> shortcut.
 </p>
 ```
 
@@ -130,13 +128,10 @@ Nesting a `<samp>` element inside a `<kbd>` element represents input which is ba
 
 For example, you can explain how to choose the "New Document" option in the "File" menu using HTML that looks like this:
 
-```html
+```html-nolint
 <p>
-  To create a new file, choose the menu option
-  <kbd
-    ><kbd><samp>File</samp></kbd
-    >⇒<kbd><samp>New Document</samp></kbd></kbd
-  >.
+  To create a new file, choose the <kbd><kbd><samp>File</samp></kbd>
+  ⇒<kbd><samp>New Document</samp></kbd></kbd> menu option.
 </p>
 
 <p>
@@ -157,25 +152,17 @@ This does some interesting nesting. For the menu option description, the entire 
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
-          >Content categories</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >Flow content</a
-        >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content"
-          >phrasing content</a
-        >, palpable content.
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">Flow content</a>,
+        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">phrasing content</a>, palpable content.
       </td>
     </tr>
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content"
-          >Phrasing content</a
-        >.
+        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">Phrasing content</a>.
       </td>
     </tr>
     <tr>
@@ -186,17 +173,13 @@ This does some interesting nesting. For the menu option description, the entire 
       <th scope="row">Permitted parents</th>
       <td>
         Any element that accepts
-        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content"
-          >phrasing content</a
-        >.
+        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">phrasing content</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
-          >No corresponding role</a
-        >
+        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role">No corresponding role</a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/progress/index.md
+++ b/files/en-us/web/html/element/progress/index.md
@@ -15,28 +15,18 @@ The **`<progress>`** [HTML](/en-US/docs/Web/HTML) element displays an indicator 
   <tbody>
     <tr>
       <th scope="row">
-        <a href="/en-US/docs/Web/HTML/Content_categories"
-          >Content categories</a
-        >
+        <a href="/en-US/docs/Web/HTML/Content_categories">Content categories</a>
       </th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content"
-          >Flow content</a
-        >,
-        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content"
-          >phrasing content</a
-        >, labelable content,
-        <a href="/en-US/docs/Web/HTML/Content_categories#palpable_content"
-          >palpable content</a
-        >.
+        <a href="/en-US/docs/Web/HTML/Content_categories#flow_content">Flow content</a>,
+        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">phrasing content</a>, labelable content,
+        <a href="/en-US/docs/Web/HTML/Content_categories#palpable_content">palpable content</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Permitted content</th>
       <td>
-        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content"
-          >Phrasing content</a
-        >, but there must be no <code>&#x3C;progress></code> element among its
+        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">Phrasing content</a>, but there must be no <code>&#x3C;progress></code> element among its
         descendants.
       </td>
     </tr>
@@ -48,9 +38,7 @@ The **`<progress>`** [HTML](/en-US/docs/Web/HTML) element displays an indicator 
       <th scope="row">Permitted parents</th>
       <td>
         Any element that accepts
-        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content"
-          >phrasing content</a
-        >.
+        <a href="/en-US/docs/Web/HTML/Content_categories#phrasing_content">phrasing content</a>.
       </td>
     </tr>
     <tr>
@@ -102,9 +90,9 @@ In most cases you should provide an accessible label when using `<progress>`. Wh
 #### Examples
 
 ```html
-<label
-  >Uploading Document: <progress value="70" max="100">70 %</progress></label
->
+<label>
+  Uploading Document: <progress value="70" max="100">70 %</progress>
+</label>
 
 <!-- OR -->
 <br />

--- a/files/en-us/web/html/element/q/index.md
+++ b/files/en-us/web/html/element/q/index.md
@@ -23,9 +23,9 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 ```html
 <p>
   According to Mozilla's website,
-  <q cite="https://www.mozilla.org/en-US/about/history/details/"
-    >Firefox 1.0 was released in 2004 and became a big success.</q
-  >
+  <q cite="https://www.mozilla.org/en-US/about/history/details/">
+    Firefox 1.0 was released in 2004 and became a big success.
+  </q>
 </p>
 ```
 

--- a/files/en-us/web/html/element/select/index.md
+++ b/files/en-us/web/html/element/select/index.md
@@ -158,8 +158,8 @@ The following example creates a very simple dropdown menu, the second option of 
 The follow example is more complex, showing off more features you can use on a `<select>` element:
 
 ```html
-<label
-  >Please choose one or more pets:
+<label>
+  Please choose one or more pets:
   <select name="pets" multiple size="4">
     <optgroup label="4-legged pets">
       <option value="dog">Dog</option>

--- a/files/en-us/web/html/element/slot/index.md
+++ b/files/en-us/web/html/element/slot/index.md
@@ -51,9 +51,9 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   </style>
   <details>
     <summary>
-      <code class="name"
-        >&lt;<slot name="element-name">NEED NAME</slot>&gt;</code
-      >
+      <code class="name">
+        &lt;<slot name="element-name">NEED NAME</slot>&gt;
+      </code>
       <span class="desc"><slot name="description">NEED DESCRIPTION</slot></span>
     </summary>
     <div class="attributes">

--- a/files/en-us/web/html/element/sub/index.md
+++ b/files/en-us/web/html/element/sub/index.md
@@ -64,11 +64,10 @@ Traditional footnotes are denoted using numbers which are rendered in subscript.
 
 In mathematics, families of variables related to the same concept (such as distances along the same axis) are represented using the same variable name with a subscript following. For example:
 
-```html
+```html-nolint
 <p>
   The horizontal coordinates' positions along the X-axis are represented as
-  <var>x<sub>1</sub></var> … <var>x<sub>n</sub></var
-  >.
+  <var>x<sub>1</sub></var> … <var>x<sub>n</sub></var>.
 </p>
 ```
 

--- a/files/en-us/web/html/element/tt/index.md
+++ b/files/en-us/web/html/element/tt/index.md
@@ -29,8 +29,8 @@ This example uses `<tt>` to show text entered into, and output by, a terminal ap
 
 ```html
 <p>
-  Enter the following at the telnet command prompt: <code>set localecho</code
-  ><br />
+  Enter the following at the telnet command prompt:
+  <code>set localecho</code><br />
 
   The telnet client should display: <tt>Local Echo is on</tt>
 </p>
@@ -56,8 +56,8 @@ tt {
 
 ```html
 <p>
-  Enter the following at the telnet command prompt: <code>set localecho</code
-  ><br />
+  Enter the following at the telnet command prompt:
+  <code>set localecho</code><br />
 
   The telnet client should display: <tt>Local Echo is on</tt>
 </p>

--- a/files/en-us/web/html/global_attributes/itemprop/index.md
+++ b/files/en-us/web/html/global_attributes/itemprop/index.md
@@ -18,11 +18,11 @@ The example below shows the source for a set of elements marked up with `itempro
 ```html
 <div itemscope itemtype="http://schema.org/Movie">
   <h1 itemprop="name">Avatar</h1>
-  <span
-    >Director:
+  <span>
+    Director:
     <span itemprop="director">James Cameron</span>
-    (born August 16, 1954)</span
-  >
+    (born August 16, 1954)
+  </span>
   <span itemprop="genre">Science fiction</span>
   <a href="../movies/avatar-theatrical-trailer.html" itemprop="trailer">
     Trailer
@@ -142,8 +142,8 @@ Properties can also be groups of name-value pairs, by putting the itemscope attr
     Band:
     <span itemprop="band" itemscope>
       <span itemprop="name">Jazz Band</span>
-      (<span itemprop="size">12</span> players)</span
-    >
+      (<span itemprop="size">12</span> players)
+    </span>
   </p>
 </div>
 ```
@@ -191,8 +191,8 @@ An element introducing a property can also introduce multiple properties at once
   <span
     itemprop="favorite-color
     favorite-fruit"
-    >orange</span
-  >
+    >orange
+  </span>
 </div>
 ```
 

--- a/files/en-us/web/html/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/global_attributes/itemscope/index.md
@@ -63,10 +63,10 @@ The following example specifies the `itemtype` as "http\://schema.org/Movie", an
 ```html
 <div itemscope itemtype="https://schema.org/Movie">
   <h1 itemprop="name">Avatar</h1>
-  <span
-    >Director: <span itemprop="director">James Cameron</span> (born August 16,
-    1954)</span
-  >
+  <span>
+    Director: <span itemprop="director">James Cameron</span> (born August 16,
+    1954)
+  </span>
   <span itemprop="genre">Science fiction</span>
   <a href="https://youtu.be/0AY1XIkX7bY" itemprop="trailer">Trailer</a>
 </div>
@@ -141,7 +141,7 @@ There are four `itemscope` attributes in the following example. Each `itemscope`
       <td>recipeInstructions</td>
       <td>
         1. Cut and peel apples 2. Mix sugar and cinnamon. Use additional sugar
-        for tart apples .
+        for tart apples.
       </td>
     </tr>
     <tr>
@@ -211,14 +211,13 @@ There are four `itemscope` attributes in the following example. Each `itemscope`
   </p>
   <p>
     Published:
-    <time datetime="2022-11-05" itemprop="datePublished"
-      >November 5, 20022</time
-    >
+    <time datetime="2022-11-05" itemprop="datePublished">
+      November 5, 20022
+    </time>
   </p>
-  <span itemprop="description"
-    >This is my grandmother's apple pie recipe. I like to add a dash of
-    nutmeg.</span
-  >
+  <span itemprop="description">
+    This is my grandmother's apple pie recipe. I like to add a dash of nutmeg.
+  </span>
   <br />
   <span
     itemprop="aggregateRating"

--- a/files/en-us/web/html/global_attributes/itemtype/index.md
+++ b/files/en-us/web/html/global_attributes/itemtype/index.md
@@ -164,8 +164,8 @@ This example uses microdata attributes to represent structured data for a produc
       <meta itemprop="priceCurrency" content="USD" />
       <span itemprop="price">Sale price: $119.99<br /></span>
       (Sale ends
-      <time itemprop="priceValidUntil" datetime="2020-11-05"> 5 November!</time
-      >)<br />
+      <time itemprop="priceValidUntil" datetime="2020-11-05">5 November!</time>)
+      <br />
       Available from:
       <span
         itemprop="seller"

--- a/files/en-us/web/html/global_attributes/title/index.md
+++ b/files/en-us/web/html/global_attributes/title/index.md
@@ -29,13 +29,26 @@ The `title` attribute may contain several lines. Each `U+000A LINE FEED` (`LF`) 
 
 ```html
 <p>
-  Newlines in <code>title</code> should be taken into account, like
+  Newlines in <code>title</code> should be taken into account. This
   <span
     title="This is a
-multiline title"
-    >example</span
-  >.
+multiline title">
+    example span
+  </span>
+  has a title a attribute with a newline.
 </p>
+<hr />
+<pre id="output"></pre>
+```
+
+### JavaScript
+
+We can query the `title` attribute and display it in the empty `<pre>` element as follows:
+
+```js
+const span = document.querySelector("span");
+const output = document.querySelector("#output");
+output.textContent = span.title;
 ```
 
 ### Result

--- a/files/en-us/web/html/microformats/index.md
+++ b/files/en-us/web/html/microformats/index.md
@@ -82,9 +82,7 @@ The value of each property is defined in HTML using the class property any eleme
 <p class="h-card">
   <img class="u-photo" src="https://example.org/photo.png" alt="" />
   <a class="p-name u-url" href="https://example.org">Joe Bloggs</a>
-  <a class="u-email" href="mailto:joebloggs@example.com"
-    >joebloggs@example.com</a
-  >,
+  <a class="u-email" href="mailto:jbloggs@example.com">jbloggs@example.com</a>,
   <span class="p-street-address">17 Austerstræti</span>
   <span class="p-locality">Reykjavík</span>
   <span class="p-country-name">Iceland</span>
@@ -106,9 +104,9 @@ The value of each property is defined in HTML using the class property any eleme
 
 ```html
 <div class="h-card">
-  <a class="p-name u-url" href="https://blog.lizardwrangler.com/"
-    >Mitchell Baker</a
-  >
+  <a class="p-name u-url" href="https://blog.lizardwrangler.com/">
+    Mitchell Baker
+  </a>
   (<a class="p-org h-card" href="https://mozilla.org/">Mozilla Foundation</a>)
 </div>
 ```
@@ -155,9 +153,9 @@ Example h-entry as a blog post:
   <p>
     Published by
     <a class="p-author h-card" href="https://example.com">W. Developer</a> on
-    <time class="dt-published" datetime="2013-06-13 12:00:00"
-      >13<sup>th</sup> June 2013</time
-    >
+    <time class="dt-published" datetime="2013-06-13 12:00:00">
+      13<sup>th</sup> June 2013
+    </time>
   </p>
 
   <p class="p-summary">In which I extoll the virtues of using microformats.</p>
@@ -192,32 +190,33 @@ Example h-entry as a blog post:
       </a>
       <a
         class="p-name u-url"
-        href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106"
-        >Greg McVerry</a
-      >
+        href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106">
+        Greg McVerry
+      </a>
     </span>
     Replied to
     <a
       class="u-in-reply-to"
       href="https://developer.mozilla.org/en-US/docs/Web/HTML/microformats">
-      a post on <strong>developer.mozilla.org</strong> </a
-    >:
+      a post on <strong>developer.mozilla.org</strong>
+    </a>
+    :
   </p>
   <p class="p-name e-content">
     Hey thanks for making this microformats resource
   </p>
   <p>
-    <a href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106"
-      >Greg McVerry</a
-    >
+    <a href="https://quickthoughts.jgregorymcverry.com/profile/jgmac1106">
+      Greg McVerry
+    </a>
     published this
     <a
       class="u-url url"
-      href="https://quickthoughts.jgregorymcverry.com/2019/05/31/hey-thanks-for-making-this-microformats-resource"
-      ><time class="dt-published" datetime="2019-05-31T14:19:09+0000"
-        >31 May 2019</time
-      ></a
-    >
+      href="https://quickthoughts.jgregorymcverry.com/2019/05/31/hey-thanks-for-making-this-microformats-resource">
+      <time class="dt-published" datetime="2019-05-31T14:19:09+0000">
+        31 May 2019
+      </time>
+    </a>
   </p>
 </div>
 ```
@@ -280,9 +279,9 @@ The [h-feed](https://microformats.org/wiki/h-feed) is a stream or feed of [h-ent
     <p>
       Published by
       <a class="p-author h-card" href="https://example.com">W. Developer</a> on
-      <time class="dt-published" datetime="2013-06-13 12:00:00"
-        >13<sup>th</sup> June 2013</time
-      >
+      <time class="dt-published" datetime="2013-06-13 12:00:00">
+        13<sup>th</sup> June 2013
+      </time>
     </p>
     <p class="p-summary">
       In which I extoll the virtues of using microformats.
@@ -323,9 +322,9 @@ The `h-event` is for events on the web. h-event is often used with both event li
   <h1 class="p-name">Microformats Meetup</h1>
   <p>
     From
-    <time class="dt-start" datetime="2013-06-30 12:00"
-      >30<sup>th</sup> June 2013, 12:00</time
-    >
+    <time class="dt-start" datetime="2013-06-30 12:00">
+      30<sup>th</sup> June 2013, 12:00
+    </time>
     to <time class="dt-end" datetime="2013-06-30 18:00">18:00</time> at
     <span class="p-location">Some bar in SF</span>
   </p>
@@ -350,12 +349,14 @@ The `h-event` is for events on the web. h-event is often used with both event li
 ```html
 <div class="h-event">
   <h2 class="p-name">IndieWeb Summit</h2>
-  <time class="dt-start" datetime="2019-06-29T09:00:00-07:00"
-    >June 29, 2019 at 9:00am (-0700)</time
-  ><br />through
-  <time class="dt-end" datetime="2019-06-30T18:00:00-07:00"
-    >June 30, 2019 at 6:00pm (-0700)</time
-  ><br />
+  <time class="dt-start" datetime="2019-06-29T09:00:00-07:00">
+    June 29, 2019 at 9:00am (-0700)
+  </time>
+  <br />through
+  <time class="dt-end" datetime="2019-06-30T18:00:00-07:00">
+    June 30, 2019 at 6:00pm (-0700)
+  </time>
+  <br />
   <div class="p-location h-card">
     <div>
       <span class="p-name">Mozilla</span>
@@ -376,9 +377,9 @@ The `h-event` is for events on the web. h-event is often used with both event li
     </span>
     Published this
     <a href="https://aaronparecki.com/2019/06/29/1/" class="u-url">event </a>on
-    <time class="dt published" datetime="2019-05-25T18:00:00-07:00"
-      >May 5th, 2019</time
-    >
+    <time class="dt published" datetime="2019-05-25T18:00:00-07:00">
+      May 5th, 2019
+    </time>
   </div>
 </div>
 ```


### PR DESCRIPTION
Making a PR of changes into your feature branch as there's too much hand-picked suggestions to go into the existing PR.

Checked most (if not all) of the generated examples to see if anything is wrong and don't see any issues.

Feedback welcome regarding adding whitespace (newlines) or whether we should `nolint` instead.

Some are slightly hacky changes to make the offending elements not break over new lines